### PR TITLE
show-all

### DIFF
--- a/src/components/AdminMarkerInfo/AdminMarkerInfo.jsx
+++ b/src/components/AdminMarkerInfo/AdminMarkerInfo.jsx
@@ -66,7 +66,6 @@ AdminMarkerInfo.propTypes = {
     message: PropTypes.string,
     launched_organically: PropTypes.bool,
     picture: PropTypes.string,
-    show_on_map: PropTypes.bool,
     zip_code: PropTypes.string,
   }),
   setSelectedBox: PropTypes.func.isRequired,

--- a/src/components/AdminMarkerInfo/BoxInfo/BoxInfo.jsx
+++ b/src/components/AdminMarkerInfo/BoxInfo/BoxInfo.jsx
@@ -71,7 +71,7 @@ const BoxInfo = ({ selectedBox, setSelectedBox }) => {
             <FormLabel htmlFor="message" className={styles['form-label']}>
               Message
             </FormLabel>
-            <Textarea isReadOnly value={selectedBox.additional_comments} resize="vertical" />
+            <Textarea isReadOnly value={selectedBox.message} resize="vertical" />
           </FormControl>
           {boxHistory.length > 0 && (
             <>
@@ -114,7 +114,6 @@ BoxInfo.propTypes = {
     message: PropTypes.string,
     launched_organically: PropTypes.bool,
     picture: PropTypes.string,
-    show_on_map: PropTypes.bool,
     zip_code: PropTypes.string,
     boxholder_name: PropTypes.string,
     boxholder_email: PropTypes.string,

--- a/src/components/PickupBox/PickupBox.jsx
+++ b/src/components/PickupBox/PickupBox.jsx
@@ -18,7 +18,7 @@ import styles from './PickupBox.module.css';
 import RejectBoxPopup from '../AlertPopups/RejectBoxPopup/RejectBoxPopup';
 import PickupBoxIcon from '../BoxIcons/PickupBoxIcon.svg';
 import ApprovedBoxEmail from '../Email/EmailTemplates/ApprovedBoxEmail';
-import { FYABackend, sendEmail } from '../../common/utils';
+import { FYABackend, getLatLong, sendEmail } from '../../common/utils';
 
 const PickupBox = ({
   approved,
@@ -48,9 +48,17 @@ const PickupBox = ({
       status: 'evaluated',
       approved: true,
     });
-    await FYABackend.put('/anchorBox/update', {
-      boxID,
-      showOnMap: false,
+
+    // TODO: REPLACE US WITH COUNTRY INPUT
+    let coordinates = await getLatLong(zipCode, 'US');
+    if (coordinates.length !== 2) {
+      coordinates = [0, 0];
+    }
+
+    await FYABackend.put('/boxHistory/approveBox', {
+      transactionID,
+      latitude: coordinates[0],
+      longitude: coordinates[1],
     });
     const requests = [
       fetchBoxes('under review', true),

--- a/src/components/RelocationBox/RelocationBox.jsx
+++ b/src/components/RelocationBox/RelocationBox.jsx
@@ -100,8 +100,8 @@ const RelocationBox = ({
       message: messageState,
       launchedOrganically: launchedOrganicallyState,
     });
-    // TODO: REPLACE USA WITH COUNTRY INPUT
-    let coordinates = await getLatLong(zipCode, 'USA');
+    // TODO: REPLACE US WITH COUNTRY INPUT
+    let coordinates = await getLatLong(zipCode, 'US');
     if (coordinates.length !== 2) {
       coordinates = [0, 0];
     }


### PR DESCRIPTION
- FYA told us that they want to display all relocated/picked up boxes on the map
- Currently, submitting a pickup box will set the show_on_map column in Anchor_Box to false, you can just straight up remove that column now
- Give pickup boxes the same behavior as relocation boxes when approved (copy information to its row in Anchor_Box)
closes #111